### PR TITLE
Adding stubs for Sailfish-based transcript/isoform quantification method.

### DIFF
--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Index.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Index.scala
@@ -1,0 +1,132 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.RNAdam.algorithms.quantification
+
+import org.apache.spark.Logging
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.formats.avro.NucleotideContigFragment
+import org.bdgenomics.RNAdam.models.{ Exon, Transcript }
+
+object Index extends Serializable with Logging {
+
+  /**
+   * Computes an index, given a reference sequence, a set of transcripts, and a k-mer
+   * length. An index provides bidirectional mappings between k-mers and equivalence classes.
+   *
+   * This code is based on the implementation of Sailfish, which is described in:
+   *
+   * Patro, Rob, Stephen M. Mount, and Carl Kingsford. "Sailfish: alignment-free isoform
+   * quantification from RNA-seq reads using lightweight algorithms." arXiv preprint arXiv:1308.3700 (2013).
+   *
+   * and:
+   *
+   * Patro, Rob, Stephen M. Mount, and Carl Kingsford. "Sailfish enables alignment-free
+   * isoform quantification from RNA-seq reads using lightweight algorithms." Nature biotechnology 32.5 (2014): 462-464.
+   *
+   * @param reference An RDD containing fragments which contain reference contigs.
+   * @param transcripts An RDD containing transcripts.
+   * @param kmerLength The length _k_ of the k-mers for us to index.
+   * @return Returns a tuple containing two RDDs: the first RDD maps k-mers to equivalence class
+   *         IDs, the second maps equivalence class IDs to an iterable of member k-mers.
+   */
+  def apply(reference: RDD[NucleotideContigFragment],
+            transcripts: RDD[Transcript],
+            kmerLength: Int): (RDD[(String, Long)], RDD[(Long, Iterable[String])]) = {
+
+    // cut exons out of the reference sequence
+    val exonSequence = cutOutExons(reference, transcripts)
+
+    // given all the transcripts, find the equivalence classes
+    val (equivalenceClasses,
+      exonToClassMap) = findEquivalenceClasses(transcripts)
+
+    // cut all equivalence classes into kmers
+    val classKmers = cutClassesIntoKmers(exonSequence,
+      exonToClassMap,
+      kmerLength)
+
+    // reverse mapping (i.e., get kmer to class mapping)
+    val kmersToClasses = reverseClassMapping(classKmers)
+
+    (kmersToClasses, classKmers)
+  }
+
+  /**
+   * Given a set of transcripts and reference contigs, this method cuts out the
+   * nucleotide strings that correspond to exons. It then returns an RDD of tuples
+   * containing exon descriptors and nucleotide strings.
+   *
+   * @param contigs An RDD of reference contigs.
+   * @param transcripts An RDD of transcripts.
+   * @return Returns an RDD of exon ID/nucleotide string tuples.
+   */
+  private[quantification] def cutOutExons(contigs: RDD[NucleotideContigFragment],
+                                          transcripts: RDD[Transcript]): RDD[(String, String)] = {
+    ???
+  }
+
+  /**
+   * Given an RDD of transcripts, this method finds the k-mer equivalence classes. K-mer
+   * equivalence classes represent k-mers that show up with equal abundance across several
+   * transcripts---in our method, we simplify by just looking for exons that occur across
+   * several transcripts. This method returns two RDDs: one maps equivalence class IDs to
+   * a list of transcripts, and the other maps exon IDs to equivalence class IDs.
+   *
+   * @param transcripts An RDD of transcripts.
+   * @return Returns two RDDs: one maps equivalence class IDs to a list of transcripts,
+   *         and the other maps exon IDs to equivalence class IDs.
+   */
+  private[quantification] def findEquivalenceClasses(transcripts: RDD[Transcript]): (RDD[(Long, Iterable[String])], RDD[(String, Long)]) = {
+    ???
+  }
+
+  /**
+   * Given a list of exon IDs and the sequences of those exons, a mapping between exon IDs and
+   * equivalence classes, and a k-mer length, this method returns all k-mers which belong to
+   * all equivalence classes.
+   *
+   * @param exonSequence An RDD containing tuples with exon IDs and exon sequences.
+   * @param exonToClassMap An RDD containing tuples that map exon IDs to equivalence classes.
+   * @param kmerLength The length _k_ to use for our k-mers.
+   * @return Returns an RDD of tuples where each tuple represents an equivalence class and
+   *         its k-mers.
+   *
+   * @see reverseClassMapping
+   */
+  private[quantification] def cutClassesIntoKmers(exonSequence: RDD[(String, String)],
+                                                  exonToClassMap: RDD[(String, Long)],
+                                                  kmerLength: Int): RDD[(Long, Iterable[String])] = {
+    ???
+  }
+
+  /**
+   * This method reverses the k-mer class mapping given by the k-mer generation process. Specifically, it
+   * takes an RDD which contains the equivalence class ID and an iterator across all k-mers in that
+   * equivalence class, and returns an RDD which maps k-mer strings to equivalence class IDs.
+   *
+   * @param classesAndKmers An RDD of tuples where each tuple maps an equivalence class ID to an
+   *                        iterable which contains the k-mers that belong to the equivalence class.
+   * @return An RDD which maps k-mer strings to equivalence class IDs.
+   *
+   * @see cutClassesIntoKmers
+   */
+  private[quantification] def reverseClassMapping(classesAndKmers: RDD[(Long, Iterable[String])]): RDD[(String, Long)] = {
+    ???
+  }
+}

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Quantify.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Quantify.scala
@@ -1,0 +1,163 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.RNAdam.algorithms.quantification
+
+import org.apache.spark.Logging
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.RNAdam.models.Transcript
+
+object Quantify extends Serializable with Logging {
+
+  /**
+   *
+   * This code is based on the implementation of Sailfish, which is described in:
+   *
+   * Patro, Rob, Stephen M. Mount, and Carl Kingsford. "Sailfish: alignment-free isoform
+   * quantification from RNA-seq reads using lightweight algorithms." arXiv preprint arXiv:1308.3700 (2013).
+   *
+   * and:
+   *
+   * Patro, Rob, Stephen M. Mount, and Carl Kingsford. "Sailfish enables alignment-free
+   * isoform quantification from RNA-seq reads using lightweight algorithms." Nature biotechnology 32.5 (2014): 462-464.
+   */
+  def apply(reads: RDD[AlignmentRecord],
+            kmerToEquivalenceClass: RDD[(String, Long)],
+            equivalenceClassToTranscript: RDD[(Long, Iterable[String])],
+            transcripts: RDD[Transcript],
+            kmerLength: Int,
+            maxIterations: Int): RDD[(Transcript, Double)] = {
+
+    // cut reads into kmers
+    val readKmers = reads.adamCountKmers(kmerLength)
+
+    // map kmer counts into equivalence classes
+    val equivalenceClassCounts = mapKmersToClasses(readKmers, kmerToEquivalenceClass)
+
+    // we initialize the alphas by splitting all counts equally across transcripts
+    var alpha = initializeEM(equivalenceClassCounts,
+      equivalenceClassToTranscript)
+
+    // we initialize the µ-hat by running a first step of the M algorithm
+    var muHat = m(alpha)
+
+    // run iterations of the em algorithm
+    (0 until maxIterations).foreach(i => {
+      log.info("On iteration " + i + " of EM algorithm.")
+
+      alpha = e(muHat)
+      muHat = m(alpha)
+    })
+
+    // join transcripts up and return
+    joinTranscripts(transcripts, muHat)
+  }
+
+  /**
+   * This function takes in a set of counted kmers and a mapping between kmers and
+   * equivalence classes and returns the total count of kmers per each equivalence
+   * class.
+   *
+   * @param kmerCounts An RDD of tuples containing (the k-mer string, the number seen).
+   * @param kmerToEquivalenceClass An RDD containing tuples which map k-mer strings to
+   *                               equivalence class IDs.
+   * @return Returns an RDD containing tuples with (equivalence class ID, count).
+   */
+  private[quantification] def mapKmersToClasses(kmerCounts: RDD[(String, Long)],
+                                                kmerToEquivalenceClass: RDD[(String, Long)]): RDD[(Long, Long)] = {
+    ???
+  }
+
+  /**
+   * Initializes the EM loop by splitting all equivalence class counts equally across
+   * all transcripts. Takes in the total coverage count for all equivalence classes and
+   * the equivalence class to transcript mapping, and returns an RDD containing a tuple
+   * indicating the (transcript ID, normalized coverage, and equivalence classes that
+   * map to the transcript).
+   *
+   * @param equivalenceClassCounts An RDD containing tuples of (each equivalence class ID,
+   *                                                            the equivalence class coverage).
+   * @param equivalenceClassToTranscript An RDD of tuples mapping equivalence class IDs to
+   *                                     transcript IDs.
+   * @return Returns an RDD containing tuples of (transcript ID,
+   *                                              normalized coverage,
+   *                                              iterable of equivalence class IDs).
+   */
+  private[quantification] def initializeEM(equivalenceClassCounts: RDD[(Long, Long)],
+                                           equivalenceClassToTranscript: RDD[(Long, Iterable[String])]): RDD[(Long, Iterable[(String, Double)])] = {
+    ???
+  }
+
+  /**
+   * The expectation stage assigns a fraction of the count total per equivalence class to
+   * each transcript that the equivalence class belongs to.
+   *
+   * Per equivalence class s_j and transcript t_i, the update is:
+   *
+   * α(j,i) = \frac{µhat_i T(s_j)}{\sum_{t \supseteq s_j} µhat_t}
+   *
+   * @param transcriptWeights An RDD of tuples where each tuple contains a transcript ID,
+   *                          the normalized coverage for that transcript, and an iterable
+   *                          over the IDs of the equivalency classes that make up this transcript.
+   * @return Returns an RDD of tuples which map equivalence class IDs to an iterable of tuples which
+   *         map transcript IDs to alpha assignments.
+   */
+  private[quantification] def e(transcriptWeights: RDD[(String, Double, Iterable[Long])]): RDD[(Long, Iterable[(String, Double)])] = {
+    ???
+  }
+
+  /**
+   * The maximization step computes the relative abundance of each transcript, given the alpha
+   * assignments from each equivalence class to each transcript.
+   *
+   * Per transcript, we first perform an update:
+   *
+   * µ_i = \frac{\sum_{s_j \subseteq t_i} α(j,i)}{lhat_i}
+   *
+   * lhat_i is the adjusted length of transcript i, which equals lhat_i = l_i - k + 1.
+   *
+   * We then normalize all µ_i by:
+   *
+   * µhat_i = \frac{µ_i}{\sum_{t_j \in T} µ_j}
+   *
+   * @param equivalenceClassAssignments An RDD of tuples which map equivalence class IDs to an iterable of
+   *                                    tuples which map transcript IDs to alpha assignments.
+   * @return Returns an RDD containing tuples of (transcript ID,
+   *                                              normalized coverage,
+   *                                              iterable of equivalence class IDs).
+   */
+  private[quantification] def m(equivalenceClassAssignments: RDD[(Long, Iterable[(String, Double)])]): RDD[(String, Double, Iterable[Long])] = {
+    ???
+  }
+
+  /**
+   * This method joins the final normalized transcript expression weights against an RDD containing
+   * the full descriptors for transcripts.
+   *
+   * @param transcripts An RDD containing the full, detailed transcript descriptors.
+   * @param transcriptWeights An RDD containing tuples of (transcript ID, normalized coverage, and
+   *                          an iterable of equivalence class IDs).
+   * @return Returns an RDD containing tuples of the full transcript descriptor and the normalized coverage.
+   */
+  private[quantification] def joinTranscripts(transcripts: RDD[Transcript],
+                                              transcriptWeights: RDD[(String, Double, Iterable[Long])]): RDD[(Transcript, Double)] = {
+    ???
+  }
+}

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/models/Gene.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/models/Gene.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.RNAdam.models
+
+import org.apache.spark.SparkContext._
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.formats.avro.{ Strand, Feature }
+import scala.collection.JavaConversions._
+
+/**
+ * A 'gene model' is a small, hierarchical collection of objects: Genes, Transcripts, and Exons.
+ * Each Gene contains a collection of Transcripts, and each Transcript contains a collection of
+ * Exons, and together they describe how the genome is transcribed and translated into a family
+ * of related proteins (or other RNA products that aren't translated at all).
+ *
+ * This review,
+ * Gerstein et al. "What is a gene, post-ENCODE? History and updated definition" Genome Research (2007)
+ * http://genome.cshlp.org/content/17/6/669.full
+ *
+ * is a reasonably good overview both of what the term 'gene' has meant in the past as well as
+ * where it might be headed in the future.
+ *
+ * Here, we aren't trying to answer any of these questions about "what is a gene," but rather to
+ * provide the routines necessary to _re-assemble_ hierarchical models of genes that have been
+ * flattened into features (GFF, GTF, or BED)
+ *
+ * @param id A name, presumably unique within a gene dataset, of a Gene
+ * @param names Common names for the gene, possibly shared with other genes (for historical or
+ *              ad hoc reasons)
+ * @param strand The strand of the Gene (this is from data, not derived from the Transcripts' strand(s), and
+ *               we leave open the possibility that a single Gene will have Transcripts in _both_ directions,
+ *               e.g. anti-sense transcripts)
+ * @param transcripts The Transcripts that are part of this gene model
+ */
+case class Gene(id: String, names: Seq[String], strand: Boolean, transcripts: Iterable[Transcript]) {
+
+}
+
+/**
+ * A transcript model (here represented as a value of the Transcript class) is a simple,
+ * hierarchical model containing a collection of exon models as well as an associated
+ * gene identifier, transcript identifier, and a set of common names (synonyms).
+ *
+ * @param id the (unique) identifier of the Transcript
+ * @param names Common names for the transcript
+ * @param geneId The (unique) identifier of the gene to which the transcript belongs
+ * @param exons The set of exons in the transcript model; each of these contain a
+ *              reference region whose coordinates are in genomic space.
+ * @param cds the set of CDS regions (the subset of the exons that are coding) for this
+ *            transcript
+ * @param utrs
+ */
+case class Transcript(id: String,
+                      names: Seq[String],
+                      geneId: String,
+                      strand: Boolean,
+                      exons: Iterable[Exon],
+                      cds: Iterable[CDS],
+                      utrs: Iterable[UTR]) {
+
+}
+
+/**
+ * An exon model (here represented as a value of the Exon class) is a representation of a
+ * single exon from a transcript in genomic coordinates.
+ *
+ * NOTE: we're not handling shared exons here
+ *
+ * @param transcriptId the (unique) identifier of the transcript to which the exon belongs
+ * @param region The region (in genomic coordinates) to which the exon maps
+ */
+case class Exon(exonId: String, transcriptId: String, strand: Boolean, region: ReferenceRegion) {
+}
+
+/**
+ * Coding Sequence annotations, should be a subset of an Exon for a particular Transcript
+ * @param transcriptId
+ * @param strand
+ * @param region
+ */
+case class CDS(transcriptId: String, strand: Boolean, region: ReferenceRegion) {
+}
+
+/**
+ * UnTranslated Regions
+ *
+ * @param transcriptId
+ * @param strand
+ * @param region
+ */
+case class UTR(transcriptId: String, strand: Boolean, region: ReferenceRegion) {
+}
+


### PR DESCRIPTION
Provides stubs for #22.

I borrowed the (gutted) gene models from https://github.com/bigdatagenomics/adam/issues/327. These will be removed once the PR merges upstream.
