### PR TITLE
[RNAdam-35] Upgrades to ADAM 0.14.1-SNAPSHOT.

### DIFF
--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/models/Gene.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/models/Gene.scala
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Big Data Genomics (BDG) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <name>RNAdam: an ADAM-based RNA-seq quantification pipeline</name>
 
   <properties>
-    <adam.version>0.13.1-SNAPSHOT</adam.version>
+    <adam.version>0.14.1-SNAPSHOT</adam.version>
     <avro.version>1.7.4</avro.version>
     <java.version>1.7</java.version>
     <scala.version>2.10.3</scala.version>


### PR DESCRIPTION
Fixes #35 (and broken build) by migrating to ADAM 0.14.1-SNAPSHOT.

I didn't include any scripts to submit this to a Spark cluster; instead, we should get #15 merged.
