### PR TITLE
[RNAdam-42] Remove sequence dictionary from region join

### DIFF
--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/Defuse.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/Defuse.scala
@@ -31,7 +31,7 @@ object Defuse {
     val d = new Defuse(new GreedyVertexCover, alpha)
 
     // run
-    d.run(records, records.adamGetSequenceDictionary())
+    d.run(records)
   }
 }
 
@@ -41,13 +41,12 @@ object Defuse {
  */
 class Defuse(coverAlgorithm: SetCover, alpha: Double) {
 
-  def run(records: RDD[AlignmentRecord],
-          seqDict: SequenceDictionary): RDD[FusionEvent] = {
+  def run(records: RDD[AlignmentRecord]): RDD[FusionEvent] = {
     val (concordant, spanning, split) = classify(records)
     val (lmin, lmax) = findPercentiles(concordant)
     val graph = buildGraph(spanning, lmax)
     val fusions = bestFusions(graph)
-    val splitRecordToFusion = assignSplitsToFusions(fusions, split, seqDict, lmin, lmax)
+    val splitRecordToFusion = assignSplitsToFusions(fusions, split, lmin, lmax)
     val exactBoundary = findExactBoundaryForFusions(splitRecordToFusion)
     trueFusions(graph, exactBoundary)
   }
@@ -120,10 +119,9 @@ class Defuse(coverAlgorithm: SetCover, alpha: Double) {
    */
   def assignSplitsToFusions(fusions: RDD[ApproximateFusionEvent],
                             splitRecords: RDD[ReadPair],
-                            seqDict: SequenceDictionary,
                             lmin: Long,
                             lmax: Long): RDD[(ApproximateFusionEvent, ReadPair)] = {
-    SplitAssigner.assignSplitsToFusions(fusions, splitRecords, seqDict, lmin, lmax)
+    SplitAssigner.assignSplitsToFusions(fusions, splitRecords, lmin, lmax)
   }
 
   def findExactBoundaryForFusions(splitRecordToFusions: RDD[(ApproximateFusionEvent, ReadPair)]): RDD[(ApproximateFusionEvent, FusionEvent)] =

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssigner.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssigner.scala
@@ -45,7 +45,6 @@ object SplitAssigner {
 
   def assignSplitsToFusions(events: RDD[ApproximateFusionEvent],
                             records: RDD[ReadPair],
-                            seqDict: SequenceDictionary,
                             lmin: Long,
                             lmax: Long): RDD[(ApproximateFusionEvent, ReadPair)] = {
     val referenceRegions = referenceRegionsForEvents(events, lmin, lmax)
@@ -53,7 +52,7 @@ object SplitAssigner {
       if (rp.first.getReadMapped) Some((rp.first, rp)) else None,
       if (rp.second.getReadMapped) Some((rp.second, rp)) else None)
       .flatten)
-    RegionJoin.partitionAndJoin(events.sparkContext, seqDict, referenceRegions, flattenedRecords)(
+    RegionJoin.partitionAndJoin(events.sparkContext, referenceRegions, flattenedRecords)(
       ReferenceRegionApproximateFusionEventReferenceMapping,
       AlignmentRecordReadPairReferenceMapping,
       classTag[(ReferenceRegion, ApproximateFusionEvent)],

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssignerSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssignerSuite.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.RNAdam.algorithms.defuse
 
 import org.bdgenomics.RNAdam.models.{ ReadPair, ApproximateFusionEvent }
-import org.bdgenomics.adam.models.{ SequenceRecord, SequenceDictionary, ReferenceRegion }
+import org.bdgenomics.adam.models.ReferenceRegion
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro.{ Contig, AlignmentRecord }
 
@@ -44,8 +44,7 @@ class SplitAssignerSuite extends SparkFunSuite {
     val readPair = ReadPair(t1Record, unmappedRecord)
     val fusions = sc.parallelize(Seq(t1t2afe))
     val records = sc.parallelize(Seq(readPair))
-    val seqDict = SequenceDictionary(SequenceRecord("t1", 200), SequenceRecord("t2", 200))
-    val assignments = SplitAssigner.assignSplitsToFusions(fusions, records, seqDict, 1, 5)
+    val assignments = SplitAssigner.assignSplitsToFusions(fusions, records, 1, 5)
     assert(assignments.count() === 1)
     assert(assignments.first() === (t1t2afe, readPair))
   }
@@ -73,8 +72,7 @@ class SplitAssignerSuite extends SparkFunSuite {
     val readPairT2 = ReadPair(t2Record, unmappedRecord)
     val fusions = sc.parallelize(Seq(t1t2afe))
     val records = sc.parallelize(Seq(readPairT1, readPairT2))
-    val seqDict = SequenceDictionary(SequenceRecord("t1", 200), SequenceRecord("t2", 200))
-    val assignments = SplitAssigner.assignSplitsToFusions(fusions, records, seqDict, 1, 5)
+    val assignments = SplitAssigner.assignSplitsToFusions(fusions, records, 1, 5)
     assert(assignments.count() === 2)
     assert(assignments.collect().toSet === Set((t1t2afe, readPairT1), (t1t2afe, readPairT2)))
   }


### PR DESCRIPTION
Resolves #42. Removes the sequence dictionary that was being passed to the region join, which cleans up the build error from the downstream changes.
