### PR TITLE
Add regression based technique for calibrating k-mer counts

### DIFF
--- a/RNAdam-core/pom.xml
+++ b/RNAdam-core/pom.xml
@@ -126,6 +126,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-graphx_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Tare.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Tare.scala
@@ -1,0 +1,135 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.RNAdam.algorithms.quantification
+
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.{ LabeledPoint, LinearRegressionWithSGD }
+import scala.math.{ exp, log }
+
+object Tare extends Serializable {
+
+  /**
+   * Converts a base into an integer number. Only works for A/C/G/T, both
+   * lower and upper case. Will throw an exception for other bases, user is
+   * expected to check before passing to function.
+   *
+   * @param base The base to convert into an integer.
+   * @return Returns a mapping from a base to an integer.
+   */
+  private def idx(base: Char): Int = base match {
+    case 'A' | 'a' => 0
+    case 'C' | 'c' => 1
+    case 'G' | 'g' => 2
+    case 'T' | 't' => 3
+  }
+
+  /**
+   * @param base Base to examine.
+   * @return Returns true if the base is a "valid" base as defined by the idx function.
+   *
+   * @see idx
+   */
+  private def validBase(base: Char): Boolean = base match {
+    case 'A' | 'a' | 'C' | 'c' | 'G' | 'g' | 'T' | 't' => true
+    case _ => false
+  }
+
+  /**
+   * Hashes a dinucleotide sequence context into an integer.
+   *
+   * @param context Sequence context to hash.
+   * @return Mapping from sequence context into an int; scale is 0-15.
+   */
+  private def dinucToIdx(context: String): Int = {
+    4 * idx(context(0)) + idx(context(1))
+  }
+
+  /**
+   * @param context Dinucleotide sequence context to evaluate.
+   * @return Returns true if the context is valid. Validity is defined by the
+   *         idx function.
+   *
+   * @see idx
+   */
+  private def isValidContext(context: String): Boolean = {
+    context.length == 2 &&
+      validBase(context(0)) &&
+      validBase(context(1))
+  }
+
+  /**
+   * Featurizes a k-mer. Cuts the k-mer into dinucleotide sequence contexts, filters out invalid
+   * sequences, and then builds a feature vector that maps the log of the multiplicity to the
+   * fraction of each context occurrence.
+   *
+   * @param kmer K-mer string to featurize.
+   * @param multiplicity Observed k-mer count.
+   * @return Vector mapping k-mer to log of multiplicity and sequence context counts.
+   */
+  private[quantification] def kmerToDinucFeature(kmer: String, multiplicity: Long): LabeledPoint = {
+    // slice kmers into contexts
+    val contexts = kmer.sliding(2).filter(isValidContext).toIterable
+    assert(contexts.size > 0, "k-mer: " + kmer + " does not contain any valid contexts.")
+    val ctxReciprocal = 1.0 / contexts.size.toDouble
+
+    // populate initial context array
+    val contextCounts = Array.fill[Double](16) { 0.0 }
+
+    // update counts
+    contexts.foreach(c => contextCounts(dinucToIdx(c)) += ctxReciprocal)
+
+    new LabeledPoint(log(multiplicity.toDouble), Vectors.dense(contextCounts))
+  }
+
+  /**
+   * Translates k-mers and counts into features and then trains a linear regression model.
+   * After the model is trained, the k-mer count is recalibrated.
+   *
+   * @param kmers An RDD of k-mer strings and counts.
+   * @return Returns a calibrated RDD of k-mers and counts.
+   */
+  def calibrateKmers(kmers: RDD[(String, Long)]): RDD[(String, Long)] = {
+    // featurize kmers
+    val countAccumulator = kmers.context.accumulator(0L)
+    val multiplicityAccumulator = kmers.context.accumulator(0L)
+    val kmersAndFeatures = kmers.map(kv => {
+      countAccumulator += 1
+      multiplicityAccumulator += kv._2
+      (kv._1, kmerToDinucFeature(kv._1, kv._2))
+    }).cache()
+
+    // train linear model
+    val model = new LinearRegressionWithSGD().setIntercept(true).run(kmersAndFeatures.map(kv => kv._2))
+    val bcastModel = kmersAndFeatures.context.broadcast(model)
+
+    // compute sample mean
+    val mean = log(multiplicityAccumulator.value.toDouble / countAccumulator.value.toDouble)
+
+    // transform back 
+    val calibratedKmers = kmersAndFeatures.map(kv => {
+      (kv._1, exp(mean + (kv._2.label - bcastModel.value.predict(kv._2.features))).toLong)
+    })
+
+    // unpersist feature rdd
+    kmersAndFeatures.unpersist()
+
+    calibratedKmers
+  }
+}

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/quantification/TareSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/quantification/TareSuite.scala
@@ -1,0 +1,91 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.RNAdam.algorithms.quantification
+
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.RNAdam.utils.TranscriptGenerator
+import scala.math.{ abs, exp, log, max, min }
+import scala.util.Random
+
+class TareSuite extends SparkFunSuite {
+
+  def fpEquals(a: Double, b: Double, eps: Double = 1e-6): Boolean = {
+    abs(a - b) <= eps
+  }
+
+  test("can't process illegal k-mers") {
+    intercept[AssertionError] {
+      Tare.kmerToDinucFeature("AN", 1L)
+    }
+    intercept[AssertionError] {
+      Tare.kmerToDinucFeature("A", 10L)
+    }
+    intercept[AssertionError] {
+      Tare.kmerToDinucFeature("ANTNC", 100L)
+    }
+  }
+
+  test("chop a 2-mer into a feature") {
+    val featureAA = Tare.kmerToDinucFeature("AA", 1000L)
+    assert(fpEquals(featureAA.label, log(1000L)))
+    assert(fpEquals(featureAA.features(0), 1.0))
+    (1 to 15).foreach(i => assert(fpEquals(featureAA.features(i), 0.0)))
+
+    val featureTT = Tare.kmerToDinucFeature("TT", 100L)
+    assert(fpEquals(featureTT.label, log(100L)))
+    assert(fpEquals(featureTT.features(15), 1.0))
+    (0 to 14).foreach(i => assert(fpEquals(featureTT.features(i), 0.0)))
+  }
+
+  test("chop an 5-mer with a bad base into a feature") {
+    val feature = Tare.kmerToDinucFeature("AANTT", 4321L)
+    assert(fpEquals(feature.label, log(4321L)))
+    assert(fpEquals(feature.features(0), 0.5))
+    assert(fpEquals(feature.features(15), 0.5))
+    (1 to 14).foreach(i => assert(fpEquals(feature.features(i), 0.0)))
+  }
+
+  sparkTest("generate biased kmers and try correcting their counts") {
+    val sampleString = TranscriptGenerator.generateString(500, new Random(121212L))
+
+    // generate kmers corresponding to log space gc bias curve of 2.0 + 1.0 (gc - 0.5)
+    val kmerSamples = sampleString.sliding(15)
+      .map(s => {
+        // compute bias and use curve for count
+        val gc = s.count(c => c == 'C' || c == 'G').toDouble / 15.0
+        val count = (100.0 * exp(2.0 + 1.0 * (gc - 0.5))).toLong
+
+        (s, count)
+      }).toSeq
+
+    // build rdd and fit sequence context curve
+    val rdd = sc.parallelize(kmerSamples)
+    val originalMax = rdd.map(kv => kv._2).reduce(_ max _)
+    val originalMin = rdd.map(kv => kv._2).reduce(_ min _)
+    val calibratedRdd = Tare.calibrateKmers(rdd)
+      .cache()
+
+    // calibration should reduce max and increase min
+    val newMax = calibratedRdd.map(kv => kv._2).reduce(_ max _)
+    val newMin = calibratedRdd.map(kv => kv._2).reduce(_ min _)
+
+    assert(originalMax > newMax)
+    assert(originalMin < newMin)
+  }
+}

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/utils/TranscriptGenerator.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/utils/TranscriptGenerator.scala
@@ -39,7 +39,7 @@ object TranscriptGenerator {
    * @param rv A random variable to use.
    * @return Returns a random string composed of 'A', 'C', 'G', 'T'.
    */
-  private[utils] def generateString(length: Int, rv: Random): String = {
+  def generateString(length: Int, rv: Random): String = {
     assert(length > 0)
     val sb = new StringBuilder(length)
     (0 until length).foreach(i => {

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
+        <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
         <artifactId>spark-graphx_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
       </dependency>


### PR DESCRIPTION
Closes #54. Translates _k_-mers into dinucleotide based feature vectors, and then trains a linear regression model on these feature vectors. The mean coverage and the residual for this _k_-mer are used to remove bias.