### PR TITLE
[RNAdam-58] Upgrade to ADAM 0.15.1-SNAPSHOT

### DIFF
--- a/RNAdam-core/pom.xml
+++ b/RNAdam-core/pom.xml
@@ -101,14 +101,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.bdgenomics.bdg-utils</groupId>
+      <artifactId>bdg-utils-misc</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>        
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssigner.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssigner.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.RNAdam.algorithms.defuse
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.RNAdam.models.{ ApproximateFusionEvent, ReadPair }
 import org.bdgenomics.adam.models.{ SequenceDictionary, ReferenceMapping, ReferenceRegion }
-import org.bdgenomics.adam.rdd.RegionJoin
+import org.bdgenomics.adam.rdd.BroadcastRegionJoin
 import org.bdgenomics.adam.rich.ReferenceMappingContext.AlignmentRecordReferenceMapping
 import org.bdgenomics.formats.avro.AlignmentRecord
 import scala.reflect._
@@ -52,7 +52,7 @@ object SplitAssigner {
       if (rp.first.getReadMapped) Some((rp.first, rp)) else None,
       if (rp.second.getReadMapped) Some((rp.second, rp)) else None)
       .flatten)
-    RegionJoin.partitionAndJoin(events.sparkContext, referenceRegions, flattenedRecords)(
+    BroadcastRegionJoin.partitionAndJoin(events.sparkContext, referenceRegions, flattenedRecords)(
       ReferenceRegionApproximateFusionEventReferenceMapping,
       AlignmentRecordReadPairReferenceMapping,
       classTag[(ReferenceRegion, ApproximateFusionEvent)],

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/cliques/FindCliquesSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/cliques/FindCliquesSuite.scala
@@ -20,9 +20,9 @@ package org.bdgenomics.RNAdam.algorithms.cliques
 import org.apache.spark.SparkContext._
 import org.apache.spark.graphx.{ Edge, Graph }
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.RNAdam.utils.RNAdamFunSuite
 
-class FindCliquesSuite extends SparkFunSuite {
+class FindCliquesSuite extends RNAdamFunSuite {
 
   override val properties = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
     ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/defuse/GreedyVertexCoverSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/defuse/GreedyVertexCoverSuite.scala
@@ -17,9 +17,9 @@
  */
 package org.bdgenomics.RNAdam.algorithms.defuse
 
-import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.RNAdam.utils.RNAdamFunSuite
 
-class GreedyVertexCoverSuite extends SparkFunSuite {
+class GreedyVertexCoverSuite extends RNAdamFunSuite {
 
   override val properties = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
     ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssignerSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/defuse/SplitAssignerSuite.scala
@@ -19,10 +19,10 @@ package org.bdgenomics.RNAdam.algorithms.defuse
 
 import org.bdgenomics.RNAdam.models.{ ReadPair, ApproximateFusionEvent }
 import org.bdgenomics.adam.models.ReferenceRegion
-import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.RNAdam.utils.RNAdamFunSuite
 import org.bdgenomics.formats.avro.{ Contig, AlignmentRecord }
 
-class SplitAssignerSuite extends SparkFunSuite {
+class SplitAssignerSuite extends RNAdamFunSuite {
 
   override val properties = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
     ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/quantification/QuantifySuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/quantification/QuantifySuite.scala
@@ -19,13 +19,13 @@ package org.bdgenomics.RNAdam.algorithms.quantification
 
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ Exon, ReferenceRegion, Transcript }
-import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.RNAdam.utils.RNAdamFunSuite
 import org.bdgenomics.RNAdam.utils.{ ReadGenerator, TranscriptGenerator }
 import scala.collection.Map
 import scala.collection.immutable.HashMap
 import scala.math.abs
 
-class QuantifySuite extends SparkFunSuite {
+class QuantifySuite extends RNAdamFunSuite {
 
   def fpEquals(a: Double, b: Double, tol: Double = 1e-3): Boolean = {
     abs(a - b) < tol

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/quantification/TareSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/algorithms/quantification/TareSuite.scala
@@ -18,12 +18,12 @@
 package org.bdgenomics.RNAdam.algorithms.quantification
 
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.RNAdam.utils.RNAdamFunSuite
 import org.bdgenomics.RNAdam.utils.TranscriptGenerator
 import scala.math.{ abs, exp, log, max, min }
 import scala.util.Random
 
-class TareSuite extends SparkFunSuite {
+class TareSuite extends RNAdamFunSuite {
 
   def fpEquals(a: Double, b: Double, eps: Double = 1e-6): Boolean = {
     abs(a - b) <= eps

--- a/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/utils/RNAdamFunSuite.scala
+++ b/RNAdam-core/src/test/scala/org/bdgenomics/RNAdam/utils/RNAdamFunSuite.scala
@@ -15,19 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bdgenomics.RNAdam.algorithms.defuse
+package org.bdgenomics.RNAdam.utils
 
-import org.bdgenomics.RNAdam.utils.RNAdamFunSuite
+import org.bdgenomics.utils.misc.SparkFunSuite
 
-class ClassifySuite extends RNAdamFunSuite {
+trait RNAdamFunSuite extends SparkFunSuite {
 
-  override val properties = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
+  override val appName: String = "RNAdam"
+  override val properties: Map[String, String] = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
     ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),
-    ("spark.kryoserializer.buffer.mb", "128"),
+    ("spark.kryoserializer.buffer.mb", "4"),
     ("spark.kryo.referenceTracking", "true"))
-
-  sparkTest("put your test here") {
-    val mySc = sc // this is your SparkContext
-  }
-
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <name>RNAdam: an ADAM-based RNA-seq quantification pipeline</name>
 
   <properties>
-    <adam.version>0.14.1-SNAPSHOT</adam.version>
+    <adam.version>0.15.1-SNAPSHOT</adam.version>
     <avro.version>1.7.4</avro.version>
     <java.version>1.7</java.version>
     <scala.version>2.10.3</scala.version>
@@ -25,6 +25,7 @@
     <spark.version>1.1.0</spark.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
+    <utils.version>0.1.1</utils.version>
   </properties>
 
   <modules>
@@ -215,10 +216,26 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.bdgenomics.bdg-utils</groupId>
+        <artifactId>bdg-utils-misc</artifactId>
+        <version>${utils.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>        
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <scope>provided</scope>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
@@ -301,16 +318,19 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-graphx_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Resolves #58. Upgrades to ADAM 0.15.1-SNAPSHOT, adds RNAdamFunSuite for testing Spark based features, and moves Hadoop and Spark to provided scope.