### PR TITLE
[RNAdam-60] Remove non-ADAMContext *Context references.

### DIFF
--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/Defuse.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/defuse/Defuse.scala
@@ -22,7 +22,6 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.RNAdam.models.{ ApproximateFusionEvent, FusionEvent, ReadPair }
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 object Defuse {

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Quantify.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Quantify.scala
@@ -21,7 +21,6 @@ import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext._
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.adam.models.Transcript
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
 
   <properties>
     <adam.version>0.15.1-SNAPSHOT</adam.version>
-    <avro.version>1.7.4</avro.version>
+    <avro.version>1.7.6</avro.version>
     <java.version>1.7</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
-    <spark.version>1.1.0</spark.version>
+    <spark.version>1.2.0</spark.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
-    <utils.version>0.1.1</utils.version>
+    <utils.version>0.1.2-SNAPSHOT</utils.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Resolves #60. Upgrades to Spark 1.2.0 and Avro 1.7.4 in the process.