### PR TITLE
[RNAdam-53] Calibrate the transcript isoform abundances for transcript length bias.

### DIFF
--- a/RNAdam-core/pom.xml
+++ b/RNAdam-core/pom.xml
@@ -137,5 +137,9 @@
       <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jblas</groupId>
+      <artifactId>jblas</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Quantify.scala
+++ b/RNAdam-core/src/main/scala/org/bdgenomics/RNAdam/algorithms/quantification/Quantify.scala
@@ -44,7 +44,8 @@ object Quantify extends Serializable with Logging {
             transcripts: RDD[Transcript],
             kmerLength: Int,
             maxIterations: Int,
-            calibrateKmerBias: Boolean = true): RDD[(Transcript, Double)] = {
+            calibrateKmerBias: Boolean = true,
+            calibrateLengthBias: Boolean = true): RDD[(Transcript, Double)] = {
 
     // cache transcripts, then compute transcript lengths
     transcripts.cache()
@@ -88,6 +89,11 @@ object Quantify extends Serializable with Logging {
       alpha = e(muHat)
       muHat = m(alpha, tLen, kmerLength, relNumKmersInEC)
     })
+
+    // perform calibration to correct for transcript length bias, if desired
+    if (calibrateLengthBias) {
+      muHat = Tare.calibrateTxLenBias(muHat, tLen)
+    }
 
     // join transcripts up and return
     joinTranscripts(transcripts, muHat)

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,11 @@
         <version>${spark.version}</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jblas</groupId>
+        <artifactId>jblas</artifactId>
+        <version>1.2.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
+        <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
         <artifactId>spark-graphx_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
Calibrates the transcript isoform abundances calculated in Sailfish quantification to correct for RNA-seq's tendency to collect more reads from longer transcripts. This is done by linear regression of the natural logarithm of the transcript isoform abundance versus the natural logarithm of the transcript length.